### PR TITLE
Adding 404 pages and handing unknown parameters

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,12 +11,15 @@ require 'sinatra/link_header'
 Bundler.require
 
 BUSINESSES_PER_PAGE = 50
+DEFAULT_PAGE = 1
 
 get "/businesses" do
   content_type :json
 
-  page = params.fetch('page', 1)
+  page = params.fetch('page', DEFAULT_PAGE)
+  page = DEFAULT_PAGE unless page.to_i.to_s == page
   per_page = params.fetch('per_page', BUSINESSES_PER_PAGE)
+  per_page = BUSINESSES_PER_PAGE unless per_page.to_i.to_s == per_page
 
   get_page(page, per_page)
 end
@@ -25,6 +28,12 @@ get "/businesses/:id" do
   content_type :json
 
   params[:id].to_i.to_s == params[:id] ? get_business(params[:id]) : render_404_page
+end
+
+not_found do
+  content_type :json
+
+  render_404_page
 end
 
 def get_business id
@@ -48,5 +57,5 @@ end
 
 def render_404_page
   status 404
-  {"error": "The page you requested does not exist"}.to_json
+  {"error": "The page you requested does not exist", "documentation": "https://github.com/adamrmelnyk/ol"}.to_json
 end


### PR DESCRIPTION
- if the api is passed pages with an unknown paramater such as ?page=asdf,
  it should render the default page or per_page
- Added not_found route for unknown routes
- Added default page instead of magic number
- Added documentation page information
